### PR TITLE
Add light mode and header theme switcher

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -38,6 +38,8 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  --body-gradient: radial-gradient(ellipse at top, rgba(0, 0, 0, 0.05) 0%, transparent 50%),
+    radial-gradient(ellipse at bottom, rgba(0, 0, 0, 0.02) 0%, transparent 50%);
 }
 
 .dark {
@@ -73,6 +75,8 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(0.269 0 0);
   --sidebar-ring: oklch(0.439 0 0);
+  --body-gradient: radial-gradient(ellipse at top, rgba(255, 255, 255, 0.05) 0%, transparent 50%),
+    radial-gradient(ellipse at bottom, rgba(255, 255, 255, 0.02) 0%, transparent 50%);
 }
 
 @theme inline {
@@ -124,25 +128,24 @@
 
   body {
     @apply bg-background text-foreground;
-    background: radial-gradient(ellipse at top, rgba(255, 255, 255, 0.05) 0%, transparent 50%),
-      radial-gradient(ellipse at bottom, rgba(255, 255, 255, 0.02) 0%, transparent 50%);
+    background: var(--body-gradient);
   }
 
   /* Glassmorphism utility classes */
   .glass {
-    @apply backdrop-blur-xl bg-white/5 border border-white/10;
+    @apply backdrop-blur-xl bg-black/5 border border-black/10 dark:bg-white/5 dark:border-white/10;
   }
 
   .glass-card {
-    @apply backdrop-blur-xl bg-white/5 border border-white/10 rounded-2xl;
+    @apply backdrop-blur-xl bg-black/5 border border-black/10 dark:bg-white/5 dark:border-white/10 rounded-2xl;
   }
 
   .glass-button {
-    @apply backdrop-blur-xl bg-white/10 hover:bg-white/20 border border-white/20 rounded-xl transition-all duration-300;
+    @apply backdrop-blur-xl bg-black/10 hover:bg-black/20 border border-black/20 rounded-xl transition-all duration-300 dark:bg-white/10 dark:hover:bg-white/20 dark:border-white/20;
   }
 
   .glass-input {
-    @apply backdrop-blur-xl bg-white/5 border border-white/20 rounded-xl focus:border-white/40 focus:bg-white/10 transition-all duration-300;
+    @apply backdrop-blur-xl bg-black/5 border border-black/20 rounded-xl focus:border-black/40 focus:bg-black/10 transition-all duration-300 dark:bg-white/5 dark:border-white/20 dark:focus:border-white/40 dark:focus:bg-white/10;
   }
 
   /* iOS-inspired animations */
@@ -186,4 +189,60 @@
   .desktop-app {
     @apply min-h-screen bg-black;
   }
+}
+
+/* Light mode overrides for brand colors */
+.light .text-white {
+  color: rgb(0 0 0) !important;
+}
+.light .text-white\/40 {
+  color: rgb(0 0 0 / 0.4) !important;
+}
+.light .text-white\/50 {
+  color: rgb(0 0 0 / 0.5) !important;
+}
+.light .text-white\/60 {
+  color: rgb(0 0 0 / 0.6) !important;
+}
+.light .text-white\/70 {
+  color: rgb(0 0 0 / 0.7) !important;
+}
+.light .text-white\/80 {
+  color: rgb(0 0 0 / 0.8) !important;
+}
+.light .text-white\/90 {
+  color: rgb(0 0 0 / 0.9) !important;
+}
+.light .bg-white\/5 {
+  background-color: rgb(0 0 0 / 0.05) !important;
+}
+.light .bg-white\/10 {
+  background-color: rgb(0 0 0 / 0.1) !important;
+}
+.light .bg-white\/20 {
+  background-color: rgb(0 0 0 / 0.2) !important;
+}
+.light .bg-white\/90 {
+  background-color: rgb(0 0 0 / 0.9) !important;
+}
+.light .border-white\/5 {
+  border-color: rgb(0 0 0 / 0.05) !important;
+}
+.light .border-white\/10 {
+  border-color: rgb(0 0 0 / 0.1) !important;
+}
+.light .border-white\/20 {
+  border-color: rgb(0 0 0 / 0.2) !important;
+}
+.light .border-white\/40 {
+  border-color: rgb(0 0 0 / 0.4) !important;
+}
+.light .hover\:bg-white\/10:hover {
+  background-color: rgb(0 0 0 / 0.1) !important;
+}
+.light .hover\:bg-white\/20:hover {
+  background-color: rgb(0 0 0 / 0.2) !important;
+}
+.light .hover\:text-white:hover {
+  color: rgb(0 0 0) !important;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next"
 import { Inter, Poppins } from "next/font/google"
 import "./globals.css"
 import { ChatWidget } from "@/components/ui/chat-widget"
+import { ThemeProvider } from "@/components/theme-provider"
 
 const inter = Inter({
   subsets: ["latin"],
@@ -30,10 +31,16 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en" className={`${inter.variable} ${poppins.variable} antialiased`}>
-      <body className="min-h-screen bg-black text-white font-sans">
-        {children}
-        <ChatWidget />
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${inter.variable} ${poppins.variable} antialiased`}
+    >
+      <body className="min-h-screen bg-background text-foreground font-sans">
+        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
+          {children}
+          <ChatWidget />
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -7,6 +7,7 @@ import { Menu, X, User, Bell } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { usePathname } from "next/navigation"
 import { createClient } from "@/lib/supabase/client"
+import { ModeToggle } from "@/components/ui/mode-toggle"
 
 export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
@@ -94,6 +95,7 @@ export default function Header() {
 
           {/* Desktop Actions */}
           <div className="hidden md:flex items-center space-x-3">
+            <ModeToggle />
             {user ? (
               <>
                 <Link href="/notifications">
@@ -122,7 +124,7 @@ export default function Header() {
                   </Button>
                 </Link>
                 <Link href="/auth/sign-up">
-                  <Button size="sm" className="bg-white text-black hover:bg-white/90 ios-bounce">
+                  <Button size="sm" className="bg-black text-white hover:bg-black/90 ios-bounce dark:bg-white dark:text-black dark:hover:bg-white/90">
                     Get Started
                   </Button>
                 </Link>
@@ -145,6 +147,9 @@ export default function Header() {
       {/* Mobile Navigation */}
       {isMenuOpen && (
         <div className="md:hidden glass-card mx-4 mt-2 p-4">
+          <div className="flex justify-end mb-2">
+            <ModeToggle />
+          </div>
           <nav className="flex flex-col space-y-2">
             {navigation.map((item) => (
               <Link

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,11 +1,12 @@
-'use client'
+"use client"
 
-import * as React from 'react'
-import {
-  ThemeProvider as NextThemesProvider,
-  type ThemeProviderProps,
-} from 'next-themes'
+import * as React from "react"
+import { ThemeProvider as NextThemesProvider, type ThemeProviderProps } from "next-themes"
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+  return (
+    <NextThemesProvider {...props}>
+      {children}
+    </NextThemesProvider>
+  )
 }

--- a/components/ui/mode-toggle.tsx
+++ b/components/ui/mode-toggle.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Sun, Moon } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export function ModeToggle() {
+  const { theme, setTheme } = useTheme()
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="glass-button"
+      onClick={() => setTheme(theme === "light" ? "dark" : "light")}
+    >
+      {theme === "light" ? <Moon className="h-4 w-4" /> : <Sun className="h-4 w-4" />}
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary
- integrate `next-themes` provider and create mode toggle button
- add light mode styles and switcher to header
- include light theme overrides for glass UI and brand colors

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68ab293925148333ae7fe29de92c805f