### PR TITLE
Add admin seed script and deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
+# Varsity Scholarships
 
+## Deployment
+
+Run the SQL scripts in the `scripts` directory to initialize the database. After running the base migrations, seed an initial admin account:
+
+```bash
+psql "$DATABASE_URL" -f scripts/04-seed-admin.sql
+```
+
+This creates a corresponding user in both `auth.users` and `public.users` with `is_admin` set to `TRUE`.

--- a/scripts/04-seed-admin.sql
+++ b/scripts/04-seed-admin.sql
@@ -1,0 +1,26 @@
+-- Seed an initial admin user
+-- Inserts an admin into auth.users and public.users
+
+-- Ensure pgcrypto extension is available for gen_random_uuid() and password hashing
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+WITH existing_user AS (
+  SELECT id, email FROM auth.users WHERE email = 'barackdanieljackisa@gmail.com'
+), inserted_user AS (
+  INSERT INTO auth.users (id, email, encrypted_password, email_confirmed_at)
+  VALUES (
+    gen_random_uuid(),
+    'barackdanieljackisa@gmail.com',
+    crypt('changeme', gen_salt('bf')),
+    now()
+  )
+  ON CONFLICT (email) DO NOTHING
+  RETURNING id, email
+), target_user AS (
+  SELECT * FROM inserted_user
+  UNION
+  SELECT * FROM existing_user
+)
+INSERT INTO public.users (id, email, full_name, is_admin)
+SELECT id, email, 'Admin User', TRUE FROM target_user
+ON CONFLICT (id) DO UPDATE SET is_admin = TRUE;


### PR DESCRIPTION
## Summary
- add SQL seed script to create initial admin account with email barackdanieljackisa@gmail.com in both `auth.users` and `public.users`
- document running the admin seed script during deployment setup

## Testing
- `pnpm lint` *(fails: interactive prompt for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ab37e6a27c83338d1eb2aa32731af3