### PR TITLE
Replace events section with horizontal timeline

### DIFF
--- a/app/admin/timeline/page.tsx
+++ b/app/admin/timeline/page.tsx
@@ -1,0 +1,75 @@
+import Header from "@/components/layout/header"
+import Footer from "@/components/layout/footer"
+import { GlassCard } from "@/components/ui/glass-card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { createClient } from "@/lib/supabase/server"
+import { redirect } from "next/navigation"
+
+async function createPost(formData: FormData) {
+  "use server"
+  const supabase = createClient()
+  const type = formData.get("type")?.toString()
+  const title = formData.get("title")?.toString()
+  const content = formData.get("content")?.toString()
+  const image_url = formData.get("image_url")?.toString()
+  const link = formData.get("link")?.toString()
+  await supabase.from("timeline_posts").insert({ type, title, content, image_url, link })
+  redirect("/admin")
+}
+
+export default async function TimelineAdminPage() {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    redirect("/auth/login?redirect=/admin/timeline")
+  }
+  const { data: profile } = await supabase.from("users").select("*").eq("id", user.id).single()
+  if (!profile?.is_admin) {
+    redirect("/dashboard")
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 pt-16">
+        <section className="py-12 px-4 sm:px-6 lg:px-8">
+          <div className="max-w-3xl mx-auto">
+            <GlassCard>
+              <h1 className="text-2xl font-bold mb-6">New Timeline Post</h1>
+              <form action={createPost} className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium mb-2">Type</label>
+                  <select name="type" className="glass-input w-full">
+                    <option value="status">Status</option>
+                    <option value="job">Job</option>
+                    <option value="event">Event</option>
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-2">Title</label>
+                  <Input name="title" className="glass-input" placeholder="Optional title" />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-2">Content</label>
+                  <Textarea name="content" className="glass-input min-h-32" placeholder="Write your update" />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-2">Image URL</label>
+                  <Input name="image_url" className="glass-input" placeholder="https://" />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-2">Link</label>
+                  <Input name="link" className="glass-input" placeholder="https://" />
+                </div>
+                <Button type="submit" className="w-full bg-white text-black hover:bg-white/90 ios-bounce">Add Post</Button>
+              </form>
+            </GlassCard>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,37 +2,22 @@ import Header from "@/components/layout/header"
 import Footer from "@/components/layout/footer"
 import { GlassCard } from "@/components/ui/glass-card"
 import { Button } from "@/components/ui/button"
-import { ArrowRight, Globe, Users, Award, CheckCircle, Calendar, Clock, MapPin } from "lucide-react"
+import { ArrowRight, Globe, Users, Award, CheckCircle } from "lucide-react"
 import Link from "next/link"
-import Image from "next/image"
-import { createClient } from "@/lib/supabase/server"
-
-// Define the type for an event
-interface Event {
-  id: number
-  name: string
-  cover_photo_url: string | null
-  start_datetime: string
-  time_string: string | null
-  location: string | null
-  about: string | null
-  organizer: string | null
-  register_url: string | null
-}
+import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
+import { TimelinePost, TimelinePostCard } from "@/components/timeline/timeline-post-card"
+import { TimelineDemo } from "@/components/timeline/timeline-demo"
 
 export default async function HomePage() {
   const supabase = createClient()
 
-  // Fetch upcoming events
-  const { data: events, error } = await supabase
-    .from("events")
-    .select("*")
-    .gt("start_datetime", new Date().toISOString())
-    .order("start_datetime", { ascending: true })
-
-  if (error) {
-    console.error("Error fetching events:", error)
-    // Decide how to handle the error, maybe show a message
+  let posts: TimelinePost[] | null = null
+  if (isSupabaseConfigured) {
+    const { data } = await supabase
+      .from("timeline_posts")
+      .select("*")
+      .order("posted_at", { ascending: true })
+    posts = data
   }
 
   const services = [
@@ -133,59 +118,22 @@ export default async function HomePage() {
           </div>
         </section>
 
-        {/* Events Section */}
+        {/* Timeline Section */}
         <section className="py-16 px-4 sm:px-6 lg:px-8">
           <div className="max-w-6xl mx-auto">
             <div className="text-center mb-12">
-              <h2 className="text-3xl md:text-4xl font-bold font-serif mb-4">Upcoming Events</h2>
-              <p className="text-white/70 text-lg">
-                Join us at our upcoming events to learn more about studying abroad.
-              </p>
+              <h2 className="text-3xl md:text-4xl font-bold font-serif mb-4">Community Timeline</h2>
+              <p className="text-white/70 text-lg">Latest updates, jobs, and events.</p>
             </div>
 
-            {events && events.length > 0 ? (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                {events.map((event: Event) => (
-                  <GlassCard key={event.id} className="flex flex-col">
-                    <div className="relative h-48 w-full mb-4">
-                      <Image
-                        src={event.cover_photo_url || "/placeholder.jpg"}
-                        alt={event.name}
-                        layout="fill"
-                        objectFit="cover"
-                        className="rounded-t-lg"
-                      />
-                    </div>
-                    <div className="p-4 flex flex-col flex-grow">
-                      <h3 className="text-xl font-bold mb-2">{event.name}</h3>
-                      <div className="space-y-2 text-white/70 text-sm mb-4">
-                        <div className="flex items-center space-x-2">
-                          <Calendar className="h-4 w-4" />
-                          <span>{new Date(event.start_datetime).toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}</span>
-                        </div>
-                        <div className="flex items-center space-x-2">
-                          <Clock className="h-4 w-4" />
-                          <span>{event.time_string}</span>
-                        </div>
-                        <div className="flex items-center space-x-2">
-                          <MapPin className="h-4 w-4" />
-                          <span>{event.location}</span>
-                        </div>
-                      </div>
-                      <p className="text-white/80 text-sm mb-4 flex-grow">{event.about?.substring(0, 100)}...</p>
-                      <Link href={event.register_url || "#"} target="_blank">
-                        <Button className="w-full bg-white text-black hover:bg-white/90 ios-bounce mt-auto">
-                          Register Now
-                        </Button>
-                      </Link>
-                    </div>
-                  </GlassCard>
+            {posts && posts.length > 0 ? (
+              <div className="flex overflow-x-auto space-x-6 pb-4 snap-x snap-mandatory">
+                {posts.map((post) => (
+                  <TimelinePostCard key={post.id} post={post} />
                 ))}
               </div>
             ) : (
-              <GlassCard className="text-center py-12">
-                <p className="text-white/70 text-lg">No upcoming events at the moment. Please check back soon!</p>
-              </GlassCard>
+              <TimelineDemo />
             )}
           </div>
         </section>

--- a/components/admin/quick-actions.tsx
+++ b/components/admin/quick-actions.tsx
@@ -1,6 +1,6 @@
 import { GlassCard } from "@/components/ui/glass-card"
 import { Button } from "@/components/ui/button"
-import { Plus, Users, MessageSquare, Settings, Bell, FileText } from "lucide-react"
+import { Plus, Users, MessageSquare, Settings, Bell, FileText, Megaphone } from "lucide-react"
 import Link from "next/link"
 
 export function QuickActions() {
@@ -11,6 +11,13 @@ export function QuickActions() {
       icon: Plus,
       href: "/admin/scholarships/new",
       color: "bg-blue-500/20 text-blue-400",
+    },
+    {
+      title: "Add Timeline Post",
+      description: "Share update, job or event",
+      icon: Megaphone,
+      href: "/admin/timeline",
+      color: "bg-pink-500/20 text-pink-400",
     },
     {
       title: "Manage Applications",

--- a/components/timeline/timeline-demo.tsx
+++ b/components/timeline/timeline-demo.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import { GlassCard } from "@/components/ui/glass-card"
+import { TimelineSkeleton } from "./timeline-skeleton"
+
+const demoSlides = [
+  {
+    title: "Future events will shine here",
+    content: "You'll be able to book appointments and secure event entries right on our website.",
+  },
+  {
+    title: "No job openings yet",
+    content: "Sorry, there are currently no vacancies. Please check in again soon!",
+  },
+  {
+    title: "Global opportunities are coming",
+    content: "We'll share the best internships and scholarships from around the globe.",
+  },
+  {
+    title: "Stay tuned for updates",
+    content: "Our posts will feature here—we can't wait to have you follow our timeline.",
+  },
+]
+
+export function TimelineDemo() {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    let index = 0
+    const interval = setInterval(() => {
+      if (!container) return
+      index = (index + 1) % container.children.length
+      const child = container.children[index] as HTMLElement
+      child.scrollIntoView({ behavior: "smooth", inline: "start", block: "nearest" })
+    }, 4000)
+
+    return () => clearInterval(interval)
+  }, [])
+
+  return (
+    <div ref={containerRef} className="flex overflow-x-auto space-x-6 pb-4 snap-x snap-mandatory">
+      {[1, 2, 3].map((i) => (
+        <TimelineSkeleton key={`skeleton-${i}`} />
+      ))}
+      {demoSlides.map((slide, i) => (
+        <GlassCard key={i} className="min-w-[300px] max-w-sm flex-shrink-0 snap-center">
+          <div className="flex flex-col h-full p-4">
+            <h3 className="text-lg font-bold mb-2">{slide.title}</h3>
+            <p className="text-sm text-white/80 flex-1">{slide.content}</p>
+          </div>
+        </GlassCard>
+      ))}
+    </div>
+  )
+}
+

--- a/components/timeline/timeline-post-card.tsx
+++ b/components/timeline/timeline-post-card.tsx
@@ -1,0 +1,36 @@
+import { GlassCard } from "@/components/ui/glass-card"
+import { Button } from "@/components/ui/button"
+import Image from "next/image"
+import Link from "next/link"
+
+export interface TimelinePost {
+  id: number
+  type: "job" | "status" | "event"
+  title: string | null
+  content: string | null
+  image_url: string | null
+  link: string | null
+  posted_at: string
+}
+
+export function TimelinePostCard({ post }: { post: TimelinePost }) {
+  return (
+    <GlassCard className="min-w-[300px] max-w-sm flex-shrink-0 snap-center">
+      {post.image_url && (
+        <div className="relative h-40 w-full mb-4">
+          <Image src={post.image_url} alt={post.title || post.type} fill className="object-cover rounded-t-lg" />
+        </div>
+      )}
+      <div className="flex flex-col h-full p-4">
+        <span className="text-xs uppercase tracking-wider text-white/60 mb-2">{post.type}</span>
+        {post.title && <h3 className="text-lg font-bold mb-2">{post.title}</h3>}
+        {post.content && <p className="text-sm text-white/80 mb-4 flex-1">{post.content}</p>}
+        {post.link && (
+          <Link href={post.link} target="_blank" className="mt-auto">
+            <Button className="w-full bg-white text-black hover:bg-white/90 ios-bounce">Learn More</Button>
+          </Link>
+        )}
+      </div>
+    </GlassCard>
+  )
+}

--- a/components/timeline/timeline-skeleton.tsx
+++ b/components/timeline/timeline-skeleton.tsx
@@ -1,0 +1,14 @@
+import { GlassCard } from "@/components/ui/glass-card"
+
+export function TimelineSkeleton() {
+  return (
+    <GlassCard className="min-w-[300px] max-w-sm flex-shrink-0 overflow-hidden animate-pulse snap-center">
+      <div className="h-40 bg-white/10" />
+      <div className="p-4 space-y-3">
+        <div className="h-4 bg-white/10 rounded w-1/2" />
+        <div className="h-3 bg-white/10 rounded w-full" />
+        <div className="h-3 bg-white/10 rounded w-3/4" />
+      </div>
+    </GlassCard>
+  )
+}

--- a/scripts/06-timeline-posts.sql
+++ b/scripts/06-timeline-posts.sql
@@ -1,0 +1,29 @@
+-- Create timeline_posts table
+CREATE TABLE IF NOT EXISTS public.timeline_posts (
+  id SERIAL PRIMARY KEY,
+  type TEXT CHECK (type IN ('job','status','event')) NOT NULL,
+  title TEXT,
+  content TEXT,
+  image_url TEXT,
+  link TEXT,
+  posted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Enable RLS and policies
+ALTER TABLE public.timeline_posts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow public read access to timeline posts"
+ON public.timeline_posts FOR SELECT USING (true);
+
+CREATE POLICY "Allow admins to manage timeline posts"
+ON public.timeline_posts FOR ALL
+USING (EXISTS (SELECT 1 FROM users WHERE id = auth.uid() AND is_admin = TRUE))
+WITH CHECK (EXISTS (SELECT 1 FROM users WHERE id = auth.uid() AND is_admin = TRUE));
+
+-- Seed sample posts
+INSERT INTO public.timeline_posts (type, title, content, image_url, link, posted_at)
+VALUES
+  ('job', 'Campus Ambassador', 'Looking for campus ambassadors for the fall semester.', NULL, 'https://example.com/job', NOW() + INTERVAL '7 days'),
+  ('status', NULL, 'We just launched our new community timeline!', NULL, NULL, NOW() + INTERVAL '14 days'),
+  ('event', 'Scholarship Webinar', 'Join our webinar on applying to scholarships abroad.', '/placeholder.jpg', 'https://example.com/event', NOW() + INTERVAL '21 days')
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- replace homepage events with horizontally scrolling timeline for jobs, status posts, and events
- allow admins to create timeline posts and link form from quick actions
- add Supabase table and seed script for timeline posts with sample data
- show looping demo slides with skeleton preloaders when no timeline posts exist

## Testing
- `pnpm lint` *(fails: Next.js ESLint plugin setup prompt)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ab47b3054c8333b373c3831c01a0dc