### PR TITLE
Route admins to dashboard

### DIFF
--- a/app/admin/applications/[id]/page.tsx
+++ b/app/admin/applications/[id]/page.tsx
@@ -28,7 +28,7 @@ export default async function ApplicationDetailPage({ params }: ApplicationDetai
     .eq("id", user.id)
     .maybeSingle()
 
-  const isAdmin = userProfile?.is_admin || user.user_metadata?.is_admin
+  const isAdmin = userProfile?.is_admin
 
   if (!isAdmin) {
     redirect("/dashboard")

--- a/app/admin/applications/page.tsx
+++ b/app/admin/applications/page.tsx
@@ -27,7 +27,7 @@ export default async function AdminApplicationsPage({
     .eq("id", user.id)
     .maybeSingle()
 
-  const isAdmin = userProfile?.is_admin || user.user_metadata?.is_admin
+  const isAdmin = userProfile?.is_admin
 
   if (!isAdmin) {
     redirect("/dashboard")

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -24,7 +24,7 @@ export default async function AdminDashboard() {
     .eq("id", user.id)
     .maybeSingle()
 
-  const isAdmin = userProfile?.is_admin || user.user_metadata?.is_admin
+  const isAdmin = userProfile?.is_admin
 
   if (!isAdmin) {
     redirect("/dashboard")

--- a/app/admin/timeline/page.tsx
+++ b/app/admin/timeline/page.tsx
@@ -30,7 +30,7 @@ export default async function TimelineAdminPage() {
     .select("*")
     .eq("id", user.id)
     .maybeSingle()
-  const isAdmin = profile?.is_admin || user.user_metadata?.is_admin
+  const isAdmin = profile?.is_admin
   if (!isAdmin) {
     redirect("/dashboard")
   }

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -17,8 +17,15 @@ export default async function LoginPage({
   } = await supabase.auth.getSession()
 
   if (session) {
+    let isAdmin = false
+    const { data: profile } = await supabase
+      .from("users")
+      .select("is_admin")
+      .eq("id", session.user.id)
+      .maybeSingle()
+    isAdmin = profile?.is_admin ?? false
     const redirectTo = (searchParams.redirect as string) || "/dashboard"
-    redirect(redirectTo)
+    redirect(isAdmin ? "/admin" : redirectTo)
   }
 
   return (

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -13,7 +13,14 @@ export default async function SignUpPage() {
   } = await supabase.auth.getSession()
 
   if (session) {
-    redirect("/dashboard")
+    let isAdmin = false
+    const { data: profile } = await supabase
+      .from("users")
+      .select("is_admin")
+      .eq("id", session.user.id)
+      .maybeSingle()
+    isAdmin = profile?.is_admin ?? false
+    redirect(isAdmin ? "/admin" : "/dashboard")
   }
 
   return (

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -41,7 +41,8 @@ export default function LoginForm({ redirectTo }: LoginFormProps) {
 
   useEffect(() => {
     if (state?.success) {
-      router.push(redirectTo || "/dashboard")
+      const destination = state.isAdmin ? "/admin" : redirectTo || "/dashboard"
+      router.push(destination)
     }
   }, [state, router, redirectTo])
 


### PR DESCRIPTION
## Summary
- Redirect admins to `/admin` after login using `users.is_admin`
- Check admin flag in session to send admins to `/admin` on login or sign-up
- Gate admin pages solely by `users.is_admin`

## Testing
- `pnpm lint` *(fails: prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4d4b19888333a6abea29d9e0c09f